### PR TITLE
[FEAT] Make `Description` column optional in pull request list table; introduce new `--created-at` option

### DIFF
--- a/cmd/pullrequest/pullrequest.go
+++ b/cmd/pullrequest/pullrequest.go
@@ -65,7 +65,7 @@ func init() {
 //
 // implements common.Tableable
 func (pullrequest PullRequest) GetHeader(short bool) []string {
-	return []string{"ID", "Title", "Description", "source", "destination", "state"}
+	return []string{"ID", "TITLE", "BRANCH", "CREATED AT", "STATE"}
 }
 
 // GetRow gets the row for a table
@@ -73,12 +73,11 @@ func (pullrequest PullRequest) GetHeader(short bool) []string {
 // implements common.Tableable
 func (pullrequest PullRequest) GetRow(headers []string) []string {
 	return []string{
-		fmt.Sprintf("%d", pullrequest.ID),
+		fmt.Sprintf("#%d", pullrequest.ID),
 		pullrequest.Title,
-		pullrequest.Description,
 		pullrequest.Source.Branch.Name,
-		pullrequest.Destination.Branch.Name,
-		pullrequest.State,
+		pullrequest.CreatedOn.Format("2006-01-02 15:04:05"),
+		strings.ToUpper(pullrequest.State),
 	}
 }
 

--- a/cmd/pullrequest/pullrequests.go
+++ b/cmd/pullrequest/pullrequests.go
@@ -1,5 +1,10 @@
 package pullrequest
 
+import (
+	"fmt"
+	"strings"
+)
+
 type PullRequests []PullRequest
 
 // GetHeader gets the header for a table
@@ -24,4 +29,71 @@ func (pullrequests PullRequests) GetRowAt(index int, headers []string) []string 
 // implements common.Tableables
 func (pullrequests PullRequests) Size() int {
 	return len(pullrequests)
+}
+
+// PullRequestsWithOptions is a wrapper that supports optional columns
+type PullRequestsWithOptions struct {
+	pullrequests    []PullRequest
+	showDescription bool
+	showCreatedAt   bool
+}
+
+// NewPullRequestsWithOptions creates a new PullRequestsWithOptions
+func NewPullRequestsWithOptions(pullrequests []PullRequest, showDescription, showCreatedAt bool) PullRequestsWithOptions {
+	return PullRequestsWithOptions{
+		pullrequests:    pullrequests,
+		showDescription: showDescription,
+		showCreatedAt:   showCreatedAt,
+	}
+}
+
+// GetHeader gets the header for a table
+//
+// implements common.Tableables
+func (p PullRequestsWithOptions) GetHeader() []string {
+	headers := []string{"ID", "TITLE"}
+	if p.showDescription {
+		headers = append(headers, "DESCRIPTION")
+	}
+	headers = append(headers, "BRANCH")
+	if p.showCreatedAt {
+		headers = append(headers, "CREATED AT")
+	}
+	headers = append(headers, "STATE")
+	return headers
+}
+
+// GetRowAt gets the row for a table
+//
+// implements common.Tableables
+func (p PullRequestsWithOptions) GetRowAt(index int, headers []string) []string {
+	if index < 0 || index >= len(p.pullrequests) {
+		return []string{}
+	}
+	pullrequest := p.pullrequests[index]
+
+	row := []string{
+		fmt.Sprintf("#%d", pullrequest.ID),
+		pullrequest.Title,
+	}
+
+	if p.showDescription {
+		row = append(row, pullrequest.Description)
+	}
+
+	row = append(row, pullrequest.Source.Branch.Name)
+
+	if p.showCreatedAt {
+		row = append(row, pullrequest.CreatedOn.Format("2006-01-02 15:04:05"))
+	}
+
+	row = append(row, strings.ToUpper(pullrequest.State))
+	return row
+}
+
+// Size gets the number of elements
+//
+// implements common.Tableables
+func (p PullRequestsWithOptions) Size() int {
+	return len(p.pullrequests)
 }


### PR DESCRIPTION
The `bb pullrequest list` command's output currently prints out entire descriptions of pull requests, which can get unwieldy with lots of information irrelevant to many of the command's users.

Or at least to me it is, when I'm simply looking at branch and PR title anyways. Besides, a comparable tool, the `gh` CLI for GitHub, lists ID, title, branch, and creation date -- no description or status there, but creation date is something `bb pr list` lacks.

Improvements
========

This PR improves the `bb pullrequest list` command by making the output table more flexible and user-friendly, similar to the GitHub CLI:

**Description and Created At columns are now optional:**
--------

- By default, only the most relevant columns are shown: `ID`, `TITLE`, `BRANCH`, and `STATE`.
- Use `--description` to include the pull request description in the table.
- Use `--created-at` to include the creation date in the table.
- Both flags can be combined for full detail.

**No more table overflow:**
--------

- The default output is concise and easy to scan, even for PRs with long descriptions.

**Implementation:**
--------

- Replaced the old static table logic with a dynamic, flag-driven approach.
- No proliferation of types/functions for each column combination.

**Example usage:**
========

```sh
bb pullrequest list
bb pullrequest list --description
bb pullrequest list --created-at
bb pullrequest list --description --created-at