### PR TITLE
fix: support pipeline_pullrequest_target in pipeline list/get + fix m…

### DIFF
--- a/cmd/pipeline/target.go
+++ b/cmd/pipeline/target.go
@@ -4,16 +4,36 @@ import (
 	"encoding/json"
 
 	"bitbucket.org/gildas_cherruel/bb/cmd/commit"
+	"bitbucket.org/gildas_cherruel/bb/cmd/common"
 	"github.com/gildas/go-errors"
 )
 
+// validTargetTypes lists the target types accepted during unmarshal
+var validTargetTypes = map[string]bool{
+	"pipeline_ref_target":         true,
+	"pipeline_pullrequest_target": true,
+}
+
 // Target represents the target of a pipeline (branch, tag, etc.)
 type Target struct {
-	Type     string         `json:"type"               mapstructure:"type"`
-	RefType  string         `json:"ref_type,omitempty" mapstructure:"ref_type"`
-	RefName  string         `json:"ref_name,omitempty" mapstructure:"ref_name"`
-	Selector *Selector      `json:"selector,omitempty" mapstructure:"selector"`
-	Commit   *commit.Commit `json:"commit,omitempty"   mapstructure:"commit"`
+	Type              string           `json:"type"                          mapstructure:"type"`
+	RefType           string           `json:"ref_type,omitempty"            mapstructure:"ref_type"`
+	RefName           string           `json:"ref_name,omitempty"            mapstructure:"ref_name"`
+	Selector          *Selector        `json:"selector,omitempty"            mapstructure:"selector"`
+	Commit            *commit.Commit   `json:"commit,omitempty"              mapstructure:"commit"`
+	Source            string           `json:"source,omitempty"              mapstructure:"source"`
+	Destination       string           `json:"destination,omitempty"         mapstructure:"destination"`
+	DestinationCommit *commit.Commit   `json:"destination_commit,omitempty"  mapstructure:"destination_commit"`
+	PullRequest       *PullRequestRef  `json:"pullrequest,omitempty"         mapstructure:"pullrequest"`
+}
+
+// PullRequestRef represents a pull request reference in a pipeline target
+type PullRequestRef struct {
+	Type  string       `json:"type"            mapstructure:"type"`
+	ID    int          `json:"id"              mapstructure:"id"`
+	Title string       `json:"title,omitempty" mapstructure:"title"`
+	Draft bool         `json:"draft,omitempty" mapstructure:"draft"`
+	Links common.Links `json:"links,omitempty" mapstructure:"links"`
 }
 
 // Selector represents a pipeline selector for custom pipelines
@@ -24,6 +44,9 @@ type Selector struct {
 
 // GetType returns the target type
 func (target Target) GetType() string {
+	if target.Type != "" {
+		return target.Type
+	}
 	return "pipeline_ref_target"
 }
 
@@ -38,14 +61,21 @@ func (target Target) MarshalJSON() ([]byte, error) {
 		commitRef = target.Commit.GetReference()
 	}
 
+	var destCommitRef *commit.CommitReference
+	if target.DestinationCommit != nil {
+		destCommitRef = target.DestinationCommit.GetReference()
+	}
+
 	data, err := json.Marshal(struct {
 		Type string `json:"type"`
 		surrogate
-		CommitRef *commit.CommitReference `json:"commit,omitempty"`
+		CommitRef     *commit.CommitReference `json:"commit,omitempty"`
+		DestCommitRef *commit.CommitReference `json:"destination_commit,omitempty"`
 	}{
-		Type:      target.GetType(),
-		surrogate: surrogate(target),
-		CommitRef: commitRef,
+		Type:          target.GetType(),
+		surrogate:     surrogate(target),
+		CommitRef:     commitRef,
+		DestCommitRef: destCommitRef,
 	})
 	return data, errors.JSONMarshalError.Wrap(err)
 }
@@ -58,18 +88,28 @@ func (target *Target) UnmarshalJSON(data []byte) error {
 	var inner struct {
 		Type string `json:"type"`
 		surrogate
-		CommitReference *commit.CommitReference `json:"commit,omitempty"`
+		CommitReference     *commit.CommitReference `json:"commit,omitempty"`
+		DestCommitReference *commit.CommitReference `json:"destination_commit,omitempty"`
 	}
 
 	if err := json.Unmarshal(data, &inner); err != nil {
 		return errors.JSONUnmarshalError.WrapIfNotMe(err)
 	}
-	if inner.Type != target.GetType() {
-		return errors.JSONUnmarshalError.Wrap(errors.InvalidType.With(inner.Type, target.GetType()))
+	if !validTargetTypes[inner.Type] {
+		return errors.JSONUnmarshalError.Wrap(errors.InvalidType.With(inner.Type, "pipeline_*_target"))
 	}
 	*target = Target(inner.surrogate)
+	target.Type = inner.Type
 	if inner.CommitReference != nil {
 		target.Commit = inner.CommitReference.AsCommit()
+	}
+	if inner.DestCommitReference != nil {
+		target.DestinationCommit = inner.DestCommitReference.AsCommit()
+	}
+
+	// For PR targets, populate RefName from source branch for display compatibility
+	if inner.Type == "pipeline_pullrequest_target" && target.Source != "" {
+		target.RefName = target.Source
 	}
 
 	return nil

--- a/cmd/user/user.go
+++ b/cmd/user/user.go
@@ -145,18 +145,35 @@ func (user User) String() string {
 
 // MarshalJSON implements the json.Marshaler interface.
 func (user User) MarshalJSON() (data []byte, err error) {
-	type surrogate User
 	var createdOn string
 
 	if !user.CreatedOn.IsZero() {
 		createdOn = user.CreatedOn.Format("2006-01-02T15:04:05.999999999-07:00")
 	}
 	data, err = json.Marshal(struct {
-		surrogate
-		CreatedOn string `json:"created_on,omitempty"`
+		Type          string       `json:"type,omitempty"`
+		ID            common.UUID  `json:"uuid,omitempty"`
+		AccountID     string       `json:"account_id,omitempty"`
+		Username      string       `json:"username,omitempty"`
+		Name          string       `json:"display_name,omitempty"`
+		Nickname      string       `json:"nickname,omitempty"`
+		Raw           string       `json:"raw,omitempty"`
+		Kind          string       `json:"kind,omitempty"`
+		Links         common.Links `json:"links,omitempty"`
+		CreatedOn     string       `json:"created_on,omitempty"`
+		AccountStatus string       `json:"account_status,omitempty"`
 	}{
-		surrogate: surrogate(user),
-		CreatedOn: createdOn,
+		Type:          user.Type,
+		ID:            user.ID,
+		AccountID:     user.AccountID,
+		Username:      user.Username,
+		Name:          user.Name,
+		Nickname:      user.Nickname,
+		Raw:           user.Raw,
+		Kind:          user.Kind,
+		Links:         user.Links,
+		CreatedOn:     createdOn,
+		AccountStatus: user.AccountStatus,
 	})
 	return data, errors.JSONMarshalError.Wrap(err)
 }

--- a/testdata/pipeline-pr.json
+++ b/testdata/pipeline-pr.json
@@ -1,0 +1,90 @@
+{
+  "type": "pipeline",
+  "uuid": "{b2c3d4e5-f6a7-8901-bcde-f12345678901}",
+  "build_number": 2808,
+  "state": {
+    "type": "pipeline_state_completed",
+    "name": "COMPLETED",
+    "result": {
+      "type": "pipeline_state_completed_failed",
+      "name": "FAILED"
+    }
+  },
+  "target": {
+    "type": "pipeline_pullrequest_target",
+    "source": "frontend-develop-non-delete-key",
+    "destination": "main",
+    "destination_commit": {
+      "type": "commit",
+      "hash": "8dc910c779d5"
+    },
+    "pullrequest": {
+      "type": "pullrequest",
+      "id": 62,
+      "title": "feat: add API key authentication",
+      "draft": false,
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/myworkspace/my-repo/pullrequests/62"
+        },
+        "html": {
+          "href": "https://bitbucket.org/myworkspace/my-repo/pull-requests/62"
+        }
+      }
+    },
+    "selector": {
+      "type": "custom",
+      "pattern": "run-tests"
+    },
+    "commit": {
+      "type": "commit",
+      "hash": "3c80cde6b371"
+    }
+  },
+  "created_on": "2024-02-20T14:00:00+00:00",
+  "completed_on": "2024-02-20T14:10:30+00:00",
+  "duration_in_seconds": 630,
+  "creator": {
+    "type": "user",
+    "uuid": "{12345678-1234-1234-1234-123456789012}",
+    "account_id": "557058:12345678-abcd-efgh-ijkl-123456789012",
+    "display_name": "John Developer",
+    "nickname": "johnd",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/%7B12345678-1234-1234-1234-123456789012%7D"
+      },
+      "avatar": {
+        "href": "https://secure.gravatar.com/avatar/abc123"
+      },
+      "html": {
+        "href": "https://bitbucket.org/%7B12345678-1234-1234-1234-123456789012%7D/"
+      }
+    }
+  },
+  "repository": {
+    "type": "repository",
+    "uuid": "{repo-uuid-1234-5678-abcd}",
+    "name": "my-repo",
+    "full_name": "myworkspace/my-repo",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/myworkspace/my-repo"
+      },
+      "html": {
+        "href": "https://bitbucket.org/myworkspace/my-repo"
+      },
+      "avatar": {
+        "href": "https://bytebucket.org/ravatar/%7Brepo-uuid%7D"
+      }
+    }
+  },
+  "links": {
+    "self": {
+      "href": "https://api.bitbucket.org/2.0/repositories/myworkspace/my-repo/pipelines/%7Bb2c3d4e5-f6a7-8901-bcde-f12345678901%7D"
+    },
+    "steps": {
+      "href": "https://api.bitbucket.org/2.0/repositories/myworkspace/my-repo/pipelines/%7Bb2c3d4e5-f6a7-8901-bcde-f12345678901%7D/steps/"
+    }
+  }
+}


### PR DESCRIPTION
…arshal round-trip

The Bitbucket API returns pipeline_pullrequest_target for PR-triggered pipelines, but UnmarshalJSON only accepted pipeline_ref_target, causing crashes on any repo with PR pipelines.

Changes:
- Accept both pipeline_ref_target and pipeline_pullrequest_target types
- Add Source, Destination, DestinationCommit, PullRequest fields to Target
- Populate RefName from PR source branch for display compatibility
- Fix Commit.MarshalJSON to not serialize zero-value nested structs
- Fix Repository.MarshalJSON to omit empty reference-only fields
- Fix User.MarshalJSON to use omitempty on all optional fields
- Add tests for PR pipeline unmarshal, GetRow branch, unknown type rejection

Tested against live Bitbucket API: pipeline get 2808 (PR) now works, pipeline get 2813 (branch push) still works (no regression).