### PR TITLE
Fix pullrequest update --destination failing with nil repository

### DIFF
--- a/cmd/pullrequest/pullrequest_test.go
+++ b/cmd/pullrequest/pullrequest_test.go
@@ -93,3 +93,26 @@ func (suite *PullRequestSuite) TestCanUnmarshal() {
 	suite.Require().NoError(err)
 	suite.Assert().JSONEq(string(payload), string(data))
 }
+
+func (suite *PullRequestSuite) TestCanUnmarshalWithNilDestinationRepository() {
+	payload := suite.LoadTestData("pullrequest-no-dest-repo.json")
+	var pr pullrequest.PullRequest
+	err := json.Unmarshal(payload, &pr)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(pr)
+	suite.Assert().Nil(pr.Destination.Repository)
+	suite.Assert().NotEmpty(pr.Destination.Branch.Name)
+}
+
+func (suite *PullRequestSuite) TestDestinationRepositoryIsNilAfterSettingNewDestination() {
+	payload := suite.LoadTestData("pullrequest.json")
+	var pr pullrequest.PullRequest
+	err := json.Unmarshal(payload, &pr)
+	suite.Require().NoError(err)
+	suite.Require().NotNil(pr.Destination.Repository)
+
+	pr.Destination = pullrequest.Endpoint{Branch: pullrequest.Branch{Name: "new-branch"}}
+
+	suite.Assert().Nil(pr.Destination.Repository)
+	suite.Assert().Equal("new-branch", pr.Destination.Branch.Name)
+}

--- a/cmd/pullrequest/update.go
+++ b/cmd/pullrequest/update.go
@@ -120,7 +120,12 @@ func updateProcess(cmd *cobra.Command, args []string) error {
 		updateWanted = true
 	}
 
-	pullrequestWorkspace, err := pullrequest.Destination.Repository.FetchWorkspace(cmd.Context(), cmd, profile)
+	var pullrequestWorkspace *workspace.Workspace
+	if pullrequest.Destination.Repository != nil {
+		pullrequestWorkspace, err = pullrequest.Destination.Repository.FetchWorkspace(cmd.Context(), cmd, profile)
+	} else {
+		pullrequestWorkspace, err = workspace.GetWorkspaceFromCommandOrGit(cmd.Context(), cmd)
+	}
 	if err != nil {
 		log.Errorf("Failed to get workspace of pullrequest destination repository", err)
 		fmt.Fprintf(os.Stderr, "Failed to get workspace of pullrequest destination repository: %s\n", err)

--- a/testdata/pullrequest-no-dest-repo.json
+++ b/testdata/pullrequest-no-dest-repo.json
@@ -1,0 +1,153 @@
+    {
+      "comment_count": 0,
+      "task_count": 0,
+      "type": "pullrequest",
+      "id": 2,
+      "title": "Merge feature/links",
+      "description": "Feature links. Do not delete the feature branch after the merge.",
+      "state": "MERGED",
+      "merge_commit": {
+        "type": "commit",
+        "hash": "5663ada8560f",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/commit/5663ada8560f"
+          },
+          "html": {
+            "href": "https://bitbucket.org/gildas_cherruel/gitflow-pr-sandbox/commits/5663ada8560f"
+          }
+        }
+      },
+      "close_source_branch": false,
+      "closed_by": {
+        "display_name": "Gildas Cherruel",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/users/%7B4115785a-a1b9-4887-9af2-ca401bc7f168%7D"
+          },
+          "avatar": {
+            "href": "https://secure.gravatar.com/avatar/30dbb120d3b75aaa0cec44e826c85cd7?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FGC-0.png"
+          },
+          "html": {
+            "href": "https://bitbucket.org/%7B4115785a-a1b9-4887-9af2-ca401bc7f168%7D/"
+          }
+        },
+        "type": "user",
+        "uuid": "{4115785a-a1b9-4887-9af2-ca401bc7f168}",
+        "account_id": "557058:ec46c4b2-f245-496e-8c11-1404869e3346",
+        "nickname": "gildas_cherruel"
+      },
+      "author": {
+        "type": "app_user",
+        "links": {
+          "avatar": {
+            "href": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/712020:9b210b18-797d-404e-a6a8-31f00569af8b/3076be80-e7af-4b62-a4b8-ed8fe3c3332e/128"
+          }
+        },
+        "created_on": "2023-10-31T08:58:32.098157+00:00",
+        "display_name": "gitflow",
+        "uuid": "{101398a7-7609-4eb5-ae20-92014abfbeb6}",
+        "account_id": "712020:9b210b18-797d-404e-a6a8-31f00569af8b",
+        "account_status": "active",
+        "kind": "repository_access_token"
+      },
+      "reason": "",
+      "created_on": "2023-10-31T11:25:52.591232+00:00",
+      "updated_on": "2023-10-31T12:24:15.443103+00:00",
+      "destination": {
+        "branch": {
+          "name": "dev"
+        },
+        "commit": {
+          "type": "commit",
+          "hash": "67a6aa42721a",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/commit/67a6aa42721a"
+            },
+            "html": {
+              "href": "https://bitbucket.org/gildas_cherruel/gitflow-pr-sandbox/commits/67a6aa42721a"
+            }
+          }
+        },
+        "repository": null
+      },
+      "source": {
+        "branch": {
+          "name": "feature/links"
+        },
+        "commit": {
+          "type": "commit",
+          "hash": "2ae150fc05f8",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/commit/2ae150fc05f8"
+            },
+            "html": {
+              "href": "https://bitbucket.org/gildas_cherruel/gitflow-pr-sandbox/commits/2ae150fc05f8"
+            }
+          }
+        },
+        "repository": {
+          "type": "repository",
+          "full_name": "gildas_cherruel/gitflow-pr-sandbox",
+          "links": {
+            "self": {
+              "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox"
+            },
+            "html": {
+              "href": "https://bitbucket.org/gildas_cherruel/gitflow-pr-sandbox"
+            },
+            "avatar": {
+              "href": "https://bytebucket.org/ravatar/%7Bf12769c1-7465-4a94-b265-8b1b04e07cb5%7D?ts=go"
+            }
+          },
+          "name": "gitflow-pr-sandbox",
+          "uuid": "{f12769c1-7465-4a94-b265-8b1b04e07cb5}"
+        }
+      },
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2"
+        },
+        "html": {
+          "href": "https://bitbucket.org/gildas_cherruel/gitflow-pr-sandbox/pull-requests/2"
+        },
+        "commits": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/commits"
+        },
+        "approve": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/approve"
+        },
+        "request-changes": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/request-changes"
+        },
+        "diff": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/diff/gildas_cherruel/gitflow-pr-sandbox:2ae150fc05f8%0D67a6aa42721a?from_pullrequest_id=2&topic=true"
+        },
+        "diffstat": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/diffstat/gildas_cherruel/gitflow-pr-sandbox:2ae150fc05f8%0D67a6aa42721a?from_pullrequest_id=2&topic=true"
+        },
+        "comments": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/comments"
+        },
+        "activity": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/activity"
+        },
+        "merge": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/merge"
+        },
+        "decline": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/decline"
+        },
+        "statuses": {
+          "href": "https://api.bitbucket.org/2.0/repositories/gildas_cherruel/gitflow-pr-sandbox/pullrequests/2/statuses"
+        }
+      },
+      "summary": {
+        "type": "rendered",
+        "raw": "Feature links. Do not delete the feature branch after the merge.",
+        "markup": "markdown",
+        "html": "<p>Feature links. Do not delete the feature branch after the merge.</p>"
+      }
+    }


### PR DESCRIPTION
## Summary

- Fix `pullrequest update --destination` failing with "Argument repository is missing"
- When changing the destination branch, `Destination.Repository` becomes nil, causing `FetchWorkspace` to fail
- Add nil check with fallback to `GetWorkspaceFromCommandOrGit`

## Changes

- `cmd/pullrequest/update.go`: Add nil check before calling `FetchWorkspace`
- `cmd/pullrequest/pullrequest_test.go`: Add tests for nil destination repository handling
- `testdata/pullrequest-no-dest-repo.json`: Test fixture for PR with null destination repository

## Testing

Manually tested retargeting a PR's destination branch successfully.