### PR TITLE
Add --limit flag and default sort to pipeline list

### DIFF
--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -36,7 +36,7 @@ func init() {
 	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pipelines from. Defaults to the current repository")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter pipelines")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")
-	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by")
+	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by (applies a local sort on fetched results; server-side sort is always by creation date descending)")
 	listCmd.Flags().IntVar(&listOptions.PageLength, "page-length", 0, "Number of items per page to retrieve from Bitbucket. Default is the profile's default page length")
 	listCmd.Flags().IntVar(&listOptions.Limit, "limit", 0, "Maximum total number of items to retrieve. 0 means no limit")
 	_ = listCmd.RegisterFlagCompletionFunc(listOptions.Columns.CompletionFunc("columns"))

--- a/cmd/profile/profile_client.go
+++ b/cmd/profile/profile_client.go
@@ -104,11 +104,16 @@ func GetAll[T any](context context.Context, cmd *cobra.Command, uripath string) 
 		}
 	}
 
-	if !strings.Contains(uripath, "pagelen") && pageLength > 0 {
+	effectivePageLength := pageLength
+	if limit > 0 && (effectivePageLength == 0 || limit < effectivePageLength) {
+		effectivePageLength = limit
+	}
+
+	if !strings.Contains(uripath, "pagelen") && effectivePageLength > 0 {
 		if strings.Contains(uripath, "?") {
-			uripath = fmt.Sprintf("%s&pagelen=%d", uripath, pageLength)
+			uripath = fmt.Sprintf("%s&pagelen=%d", uripath, effectivePageLength)
 		} else {
-			uripath = fmt.Sprintf("%s?pagelen=%d", uripath, pageLength)
+			uripath = fmt.Sprintf("%s?pagelen=%d", uripath, effectivePageLength)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `--limit` flag to `pipeline list` to cap total results, breaking the pagination loop early in `GetAll`
- Default to `sort=-created_on` so newest pipelines are returned first
- The `--limit` support in `GetAll` is generic — other list commands can opt in by registering the same flag

## Motivation

`bb pipeline list` hangs on repositories with many pipelines because `GetAll` fetches every page before returning any output. Unlike `pullrequest list` (which defaults to `state=OPEN`), pipeline list has no default filter and fetches all historical pipelines.

## Usage

```bash
bb pipeline list --limit 20        # 20 most recent pipelines
bb pipeline list                   # all pipelines (newest first now)
```

## Test plan

- [ ] `bb pipeline list --limit 10` returns exactly 10 pipelines
- [ ] `bb pipeline list --limit 10` completes quickly (1-2 API calls)
- [ ] `bb pipeline list` without `--limit` still works, now sorted newest first
- [ ] `bb pipeline list --limit 5 --query 'state.name="SUCCESSFUL"'` respects both flags

Fixes #57

