### PR TITLE
Add --limit flag and default sort to pipeline list

### DIFF
--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -65,6 +65,8 @@ func listProcess(cmd *cobra.Command, args []string) (err error) {
 		fmt.Println("No pipelines found")
 		return nil
 	}
-	core.Sort(pipelines, columns.SortBy(listOptions.SortBy.Value))
+	if cmd.Flag("sort").Changed {
+		core.Sort(pipelines, columns.SortBy(listOptions.SortBy.Value))
+	}
 	return profile.Current.Print(cmd.Context(), cmd, Pipelines(pipelines))
 }

--- a/cmd/profile/profile_client.go
+++ b/cmd/profile/profile_client.go
@@ -117,7 +117,11 @@ func GetAll[T any](context context.Context, cmd *cobra.Command, uripath string) 
 		}
 	}
 
-	log.Infof("Getting all resources for profile %s (%d at a time)", profile.Name, pageLength)
+	if limit > 0 {
+		log.Infof("Getting up to %d resources for profile %s (%d at a time)", limit, profile.Name, effectivePageLength)
+	} else {
+		log.Infof("Getting all resources for profile %s (%d at a time)", profile.Name, effectivePageLength)
+	}
 	for {
 		var paginated PaginatedResources[T]
 
@@ -135,13 +139,26 @@ func GetAll[T any](context context.Context, cmd *cobra.Command, uripath string) 
 			resources = resources[:limit]
 			break
 		}
-		log.Debugf("Got %d resources", len(paginated.Values))
+		log.Debugf("Got %d resources (total: %d)", len(paginated.Values), len(resources))
 		log.Debugf("Next page:     %s", paginated.Next)
 		log.Debugf("Previous page: %s", paginated.Previous)
 		if len(paginated.Next) == 0 {
 			break
 		}
 		uripath = paginated.Next
+		if limit > 0 {
+			remaining := limit - len(resources)
+			if remaining < effectivePageLength {
+				// Adjust pagelen on the next URL to only fetch what we still need
+				nextURL, parseErr := url.Parse(uripath)
+				if parseErr == nil {
+					query := nextURL.Query()
+					query.Set("pagelen", fmt.Sprintf("%d", remaining))
+					nextURL.RawQuery = query.Encode()
+					uripath = nextURL.String()
+				}
+			}
+		}
 	}
 	return resources, nil
 }


### PR DESCRIPTION
## Summary

- Add `--limit` flag to `pipeline list` to cap total results, breaking the pagination loop early in `GetAll`
- Default to `sort=-created_on` so newest pipelines are returned first
- Cap `pagelen` to `min(pageLength, limit)` to avoid over-fetching from the API
- The `--limit` support in `GetAll` is generic — other list commands can opt in by registering the same flag

## Motivation

`bb pipeline list` hangs on repositories with many pipelines because `GetAll` fetches every page before returning any output. Unlike `pullrequest list` (which defaults to `state=OPEN`), pipeline list has no default filter and fetches all historical pipelines.

## Usage

```bash
bb pipeline list --limit 20        # 20 most recent pipelines
bb pipeline list                   # all pipelines (newest first now)
```

## Test plan

- [ ] `bb pipeline list --limit 10` returns exactly 10 pipelines
- [ ] `bb pipeline list --limit 10` completes quickly (1-2 API calls)
- [ ] `bb pipeline list` without `--limit` still works, now sorted newest first
- [ ] `bb pipeline list --limit 5 --query 'state.name="SUCCESSFUL"'` respects both flags

Fixes #57

Resubmitted against `dev` with signed commits per maintainer request (replaces #58).