### PR TITLE
profile: preserve initial query params when following paginated Next

### DIFF
--- a/cmd/profile/profile_client.go
+++ b/cmd/profile/profile_client.go
@@ -116,6 +116,11 @@ func GetAll[T any](context context.Context, cmd *cobra.Command, uripath string) 
 		}
 	}
 
+	originalQuery := url.Values{}
+	if parsed, err := url.Parse(uripath); err == nil {
+		originalQuery = parsed.Query()
+	}
+
 	if limit > 0 {
 		log.Infof("Getting up to %d resources for profile %s (%d at a time)", limit, profile.Name, pageLength)
 	} else {
@@ -144,20 +149,28 @@ func GetAll[T any](context context.Context, cmd *cobra.Command, uripath string) 
 		if len(paginated.Next) == 0 {
 			break
 		}
-		uripath = paginated.Next
+
+		nextURL, parseErr := url.Parse(paginated.Next)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		nextQuery := nextURL.Query()
+		for key, values := range originalQuery {
+			if _, exists := nextQuery[key]; !exists {
+				for _, value := range values {
+					nextQuery.Add(key, value)
+				}
+			}
+		}
 		if limit > 0 {
 			remaining := limit - len(resources)
 			if remaining < pageLength {
 				// Adjust pagelen on the next URL to only fetch what we still need
-				nextURL, parseErr := url.Parse(uripath)
-				if parseErr == nil {
-					query := nextURL.Query()
-					query.Set("pagelen", fmt.Sprintf("%d", remaining))
-					nextURL.RawQuery = query.Encode()
-					uripath = nextURL.String()
-				}
+				nextQuery.Set("pagelen", fmt.Sprintf("%d", remaining))
 			}
 		}
+		nextURL.RawQuery = nextQuery.Encode()
+		uripath = nextURL.String()
 	}
 	return resources, nil
 }

--- a/cmd/profile/profile_client_test.go
+++ b/cmd/profile/profile_client_test.go
@@ -1,0 +1,108 @@
+package profile_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"bitbucket.org/gildas_cherruel/bb/cmd/profile"
+	"github.com/gildas/go-logger"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+type testItem struct {
+	ID string `json:"id"`
+}
+
+func TestGetAll_OriginalQueryIsPreservedForNextMissingParams(t *testing.T) {
+	oldCurrent := profile.Current
+	defer func() { profile.Current = oldCurrent }()
+
+	const filter = `target.ref_name="my-branch"`
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if r.URL.Path == "/pipelines" {
+			if r.URL.Query().Get("page") == "" {
+				assert.Equal(t, filter, q, "initial request should include original q")
+				resp := map[string]interface{}{
+					"values": []map[string]string{{"id": "1"}},
+					"next":   server.URL + "/pipelines?page=2&pagelen=1",
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			assert.Equal(t, filter, q, "second request should include original q even when next omits it")
+			resp := map[string]interface{}{
+				"values": []map[string]string{{"id": "2"}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	apiRoot, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	profile.Current = &profile.Profile{APIRoot: apiRoot, DefaultPageLength: 0, AccessToken: "fake-token"}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().Int("page-length", 0, "")
+	ctx := logger.Create("test").ToContext(context.Background())
+	items, err := profile.GetAll[testItem](ctx, cmd, server.URL+"/pipelines?pagelen=1&q="+url.QueryEscape(filter))
+	assert.NoError(t, err)
+	assert.Len(t, items, 2)
+	assert.Equal(t, "1", items[0].ID)
+	assert.Equal(t, "2", items[1].ID)
+}
+
+func TestGetAll_DoesNotOverwriteExistingNextParams(t *testing.T) {
+	oldCurrent := profile.Current
+	defer func() { profile.Current = oldCurrent }()
+
+	const originalFilter = `target.ref_name="original"`
+	const nextFilter = `target.ref_name="different"`
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if r.URL.Path == "/pipelines" {
+			if r.URL.Query().Get("page") == "" {
+				assert.Equal(t, originalFilter, q)
+				resp := map[string]interface{}{
+					"values": []map[string]string{{"id": "1"}},
+					"next":   server.URL + "/pipelines?page=2&pagelen=1&q=" + url.QueryEscape(nextFilter),
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+				return
+			}
+			assert.Equal(t, nextFilter, q, "existing q on next URL must not be overwritten")
+			resp := map[string]interface{}{
+				"values": []map[string]string{{"id": "2"}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	apiRoot, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	profile.Current = &profile.Profile{APIRoot: apiRoot, DefaultPageLength: 0, AccessToken: "fake-token"}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("profile", "", "")
+	cmd.Flags().Int("page-length", 0, "")
+	ctx := logger.Create("test").ToContext(context.Background())
+	items, err := profile.GetAll[testItem](ctx, cmd, server.URL+"/pipelines?pagelen=1&q="+url.QueryEscape(originalFilter))
+	assert.NoError(t, err)
+	assert.Len(t, items, 2)
+	assert.Equal(t, "1", items[0].ID)
+	assert.Equal(t, "2", items[1].ID)
+}


### PR DESCRIPTION
# Summary

Fix `profile.GetAll` pagination behavior so filter/query parameters stay attached through paginated `next` links. In Bitbucket API responses, `next` may omit user-supplied query filters (e.g., `q`), which earlier caused subsequent pages to return unfiltered results.

## Problem

The paginator loop in `cmd/profile/profile_client.go` replaced `uripath` with `paginated.Next` directly on each iteration. If `next` omitted query arguments (common with Bitbucket when the server cursor encodes filter state), then page 2+ would lose local filters such as `q` or custom query params, leading to broader results and broken 'find latest matching pipeline' semantics.

## Fix

- Capture original request URL query params at start: `originalQuery := parsed.Query()`
- Each `next` URL is parsed; missing keys from `originalQuery` are added to `next`'s query map without overwriting existing `next` params.
- Rebuild `nextURL.RawQuery`, assign updated `uripath` for the subsequent loop.
- Keeps server-provided pagination directives (`page`, `pagelen`, explicit `q`) intact while reapplying caller-supplied filters when dropped.

## Tests added

`cmd/profile/profile_client_test.go`
1. `TestGetAll_OriginalQueryIsPreservedForNextMissingParams`
   - first response contains values+next (`page=2&pagelen=1`, no q)
   - second page should still receive original `q` and return both items
2. `TestGetAll_DoesNotOverwriteExistingNextParams`
   - next URL explicitly includes different `q`; ensure it is respected, not replaced with original `q`

## Additional notes

- Exercise `bb pipeline list` path via `profile.GetAll` used by `cmd/pipeline/list.go`, `cmd/pipeline/common/getters.go`, and step listing paths.
- Existing failing upstream branch tests (`cmd/branch`) are unrelated to this patch.

## Checklist

- [x] Covered failure case with regression tests
- [x] No behavior regression for explicit next params
- [x] `go test ./cmd/profile ./cmd/pipeline ./cmd/branch ./cmd/workspace ./cmd/project ./cmd/issue` executed
- [x] Draft PR created