### PR TITLE
Add resolution field to PullRequestComment

### DIFF
--- a/cmd/pullrequest/comment/comment.go
+++ b/cmd/pullrequest/comment/comment.go
@@ -142,7 +142,16 @@ func (comment Comment) GetRow(headers []string) []string {
 			row = append(row, fmt.Sprintf("%t", comment.IsPending))
 		case "resolution":
 			if comment.Resolution != nil {
-				row = append(row, fmt.Sprintf("resolved by %s on %s", comment.Resolution.User.Name, comment.Resolution.CreatedOn.Format("2006-01-02 15:04:05")))
+				switch {
+				case comment.Resolution.User.Name != "" && !comment.Resolution.CreatedOn.IsZero():
+					row = append(row, fmt.Sprintf("resolved by %s on %s", comment.Resolution.User.Name, comment.Resolution.CreatedOn.Format("2006-01-02 15:04:05")))
+				case comment.Resolution.User.Name != "":
+					row = append(row, fmt.Sprintf("resolved by %s", comment.Resolution.User.Name))
+				case !comment.Resolution.CreatedOn.IsZero():
+					row = append(row, fmt.Sprintf("resolved on %s", comment.Resolution.CreatedOn.Format("2006-01-02 15:04:05")))
+				default:
+					row = append(row, "resolved")
+				}
 			} else {
 				row = append(row, "unresolved")
 			}
@@ -175,12 +184,18 @@ func (comment Comment) String() string {
 func (resolution Resolution) MarshalJSON() (data []byte, err error) {
 	type surrogate Resolution
 
+	var createdOn *string
+	if !resolution.CreatedOn.IsZero() {
+		formatted := resolution.CreatedOn.Format(time.RFC3339)
+		createdOn = &formatted
+	}
+
 	data, err = json.Marshal(struct {
 		surrogate
-		CreatedOn string `json:"created_on"`
+		CreatedOn *string `json:"created_on,omitempty"`
 	}{
 		surrogate: surrogate(resolution),
-		CreatedOn: resolution.CreatedOn.Format(time.RFC3339),
+		CreatedOn: createdOn,
 	})
 	return data, errors.JSONMarshalError.Wrap(err)
 }

--- a/cmd/pullrequest/comment/comment.go
+++ b/cmd/pullrequest/comment/comment.go
@@ -25,10 +25,17 @@ type Comment struct {
 	Parent      *Comment              `json:"parent,omitempty" mapstructure:"parent"`
 	CreatedOn   time.Time             `json:"created_on"       mapstructure:"created_on"`
 	UpdatedOn   time.Time             `json:"updated_on"       mapstructure:"updated_on"`
-	IsDeleted   bool                  `json:"deleted"          mapstructure:"deleted"`
-	IsPending   bool                  `json:"pending"          mapstructure:"pending"`
-	PullRequest *PullRequestReference `json:"pullrequest"      mapstructure:"pullrequest"`
-	Links       common.Links          `json:"links"            mapstructure:"links"`
+	IsDeleted   bool                  `json:"deleted"              mapstructure:"deleted"`
+	IsPending   bool                  `json:"pending"              mapstructure:"pending"`
+	Resolution  *Resolution           `json:"resolution,omitempty" mapstructure:"resolution"`
+	PullRequest *PullRequestReference `json:"pullrequest"          mapstructure:"pullrequest"`
+	Links       common.Links          `json:"links"                mapstructure:"links"`
+}
+
+type Resolution struct {
+	Type      string    `json:"type"       mapstructure:"type"`
+	User      user.User `json:"user"       mapstructure:"user"`
+	CreatedOn time.Time `json:"created_on" mapstructure:"created_on"`
 }
 
 type PullRequestReference struct {
@@ -77,6 +84,9 @@ var columns = common.Columns[Comment]{
 	}},
 	{Name: "pending", DefaultSorter: false, Compare: func(a, b Comment) bool {
 		return a.IsPending == b.IsPending
+	}},
+	{Name: "resolution", DefaultSorter: false, Compare: func(a, b Comment) bool {
+		return (a.Resolution != nil) && (b.Resolution == nil)
 	}},
 	{Name: "pullrequest", DefaultSorter: false, Compare: func(a, b Comment) bool {
 		if a.PullRequest != nil && b.PullRequest != nil {
@@ -130,6 +140,12 @@ func (comment Comment) GetRow(headers []string) []string {
 			row = append(row, fmt.Sprintf("%t", comment.IsDeleted))
 		case "pending":
 			row = append(row, fmt.Sprintf("%t", comment.IsPending))
+		case "resolution":
+			if comment.Resolution != nil {
+				row = append(row, fmt.Sprintf("resolved by %s on %s", comment.Resolution.User.Name, comment.Resolution.CreatedOn.Format("2006-01-02 15:04:05")))
+			} else {
+				row = append(row, "unresolved")
+			}
 		case "pullrequest":
 			if comment.PullRequest != nil {
 				row = append(row, fmt.Sprintf("%s (%d)", comment.PullRequest.Title, comment.PullRequest.ID))
@@ -153,6 +169,20 @@ func (comment *Comment) Validate() error {
 // implements fmt.Stringer
 func (comment Comment) String() string {
 	return comment.Content.Raw
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (resolution Resolution) MarshalJSON() (data []byte, err error) {
+	type surrogate Resolution
+
+	data, err = json.Marshal(struct {
+		surrogate
+		CreatedOn string `json:"created_on"`
+	}{
+		surrogate: surrogate(resolution),
+		CreatedOn: resolution.CreatedOn.Format(time.RFC3339),
+	})
+	return data, errors.JSONMarshalError.Wrap(err)
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
## Summary

- Adds `Resolution` struct (`type`, `user`, `created_on`) to the pullrequest comment package
- Adds `Resolution *Resolution` field to the `Comment` struct so it deserializes from the Bitbucket API v2.0 response
- Adds column, sorting, and table row rendering support for the `resolution` field
- Adds `MarshalJSON` on `Resolution` for consistent RFC3339 time formatting

## Context

The Bitbucket REST API v2.0 returns a `resolution` object on PR comments when they are resolved, but the CLI was dropping it at deserialization. This made it impossible for automation to determine comment resolution status without falling back to the raw REST API.

Closes #75

## Test plan

- [ ] `bb pullrequest comment list --pullrequest <ID> --output json` now includes the `resolution` key on resolved comments
- [ ] `bb pullrequest comment list --pullrequest <ID> --columns id,resolution` renders resolution status in table output
- [ ] Unresolved comments show `null`/absent resolution in JSON and "unresolved" in table output
- [ ] Existing default table output is unchanged (resolution is not in default columns)