### PR TITLE
Support bare --repository slugs with default-workspace and improve repository resolution errors

### DIFF
--- a/cmd/artifact/delete.go
+++ b/cmd/artifact/delete.go
@@ -27,7 +27,7 @@ var deleteOptions struct {
 func init() {
 	Command.AddCommand(deleteCmd)
 
-	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete artifacts from. Defaults to the current repository")
+	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete artifacts from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func deleteValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/artifact/download.go
+++ b/cmd/artifact/download.go
@@ -29,7 +29,7 @@ var downloadOptions struct {
 func init() {
 	Command.AddCommand(downloadCmd)
 
-	downloadCmd.Flags().StringVar(&downloadOptions.Repository, "repository", "", "Repository to download artifacts from. Defaults to the current repository")
+	downloadCmd.Flags().StringVar(&downloadOptions.Repository, "repository", "", "Repository to download artifacts from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	downloadCmd.Flags().StringVar(&downloadOptions.Destination, "destination", "", "Destination folder to download the artifact to. Defaults to the current folder")
 	downloadCmd.Flags().BoolVar(&downloadOptions.Progress, "progress", false, "Show progress")
 	_ = downloadCmd.MarkFlagDirname("destination")

--- a/cmd/artifact/list.go
+++ b/cmd/artifact/list.go
@@ -32,7 +32,7 @@ func init() {
 
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list artifacts from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list artifacts from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter artifacts")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")
 	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by")

--- a/cmd/artifact/upload.go
+++ b/cmd/artifact/upload.go
@@ -27,7 +27,7 @@ var uploadOptions struct {
 func init() {
 	Command.AddCommand(uploadCmd)
 
-	uploadCmd.Flags().StringVar(&uploadOptions.Repository, "repository", "", "Repository to upload artifacts to. Defaults to the current repository")
+	uploadCmd.Flags().StringVar(&uploadOptions.Repository, "repository", "", "Repository to upload artifacts to. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	uploadCmd.Flags().BoolVar(&uploadOptions.Progress, "progress", false, "Show progress")
 }
 

--- a/cmd/branch/list.go
+++ b/cmd/branch/list.go
@@ -29,7 +29,7 @@ func init() {
 
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list branches from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list branches from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter branches")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")
 	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by")

--- a/cmd/commit/get.go
+++ b/cmd/commit/get.go
@@ -28,7 +28,7 @@ func init() {
 	Command.AddCommand(getCmd)
 
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a commit from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a commit from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.RegisterFlagCompletionFunc(getOptions.Columns.CompletionFunc("columns"))
 }

--- a/cmd/commit/list.go
+++ b/cmd/commit/list.go
@@ -31,7 +31,7 @@ func init() {
 
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list commits from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list commits from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter commits")
 	listCmd.Flags().StringSliceVar(&listOptions.Include, "include", []string{}, "List of commit hashes to include")
 	listCmd.Flags().StringSliceVar(&listOptions.Exclude, "exclude", []string{}, "List of commit hashes to exclude")

--- a/cmd/component/get.go
+++ b/cmd/component/get.go
@@ -29,7 +29,7 @@ func init() {
 	Command.AddCommand(getCmd)
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
 
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a component from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a component from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.RegisterFlagCompletionFunc(getOptions.Columns.CompletionFunc("columns"))
 }

--- a/cmd/component/list.go
+++ b/cmd/component/list.go
@@ -32,7 +32,7 @@ func init() {
 
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list components from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list components from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter components")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")
 	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by")

--- a/cmd/issue/attachment/delete.go
+++ b/cmd/issue/attachment/delete.go
@@ -30,7 +30,7 @@ func init() {
 	Command.AddCommand(deleteCmd)
 
 	deleteOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
-	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete an issue attachment from. Defaults to the current repository")
+	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete an issue attachment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	deleteCmd.Flags().Var(deleteOptions.IssueID, "issue", "Issue to delete attachments from")
 	_ = deleteCmd.MarkFlagRequired("issue")
 	_ = deleteCmd.RegisterFlagCompletionFunc(deleteOptions.IssueID.CompletionFunc("issue"))

--- a/cmd/issue/attachment/download.go
+++ b/cmd/issue/attachment/download.go
@@ -31,7 +31,7 @@ func init() {
 	Command.AddCommand(downloadCmd)
 
 	downloadOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
-	downloadCmd.Flags().StringVar(&downloadOptions.Repository, "repository", "", "Repository to get an issue attachment from. Defaults to the current repository")
+	downloadCmd.Flags().StringVar(&downloadOptions.Repository, "repository", "", "Repository to get an issue attachment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	downloadCmd.Flags().Var(downloadOptions.IssueID, "issue", "Issue to get attachments from")
 	downloadCmd.Flags().StringVar(&downloadOptions.Destination, "destination", "", "Destination folder to download the attachment to. Defaults to the current folder")
 	downloadCmd.Flags().BoolVar(&downloadOptions.Progress, "progress", false, "Show progress")

--- a/cmd/issue/attachment/list.go
+++ b/cmd/issue/attachment/list.go
@@ -34,7 +34,7 @@ func init() {
 	listOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list issue attachments from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list issue attachments from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.IssueID, "issue", "Issue to list attachments from")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter attachments")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")

--- a/cmd/issue/attachment/upload.go
+++ b/cmd/issue/attachment/upload.go
@@ -29,7 +29,7 @@ func init() {
 	Command.AddCommand(uploadCmd)
 
 	uploadOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
-	uploadCmd.Flags().StringVar(&uploadOptions.Repository, "repository", "", "Repository to upload issue attachments to. Defaults to the current repository")
+	uploadCmd.Flags().StringVar(&uploadOptions.Repository, "repository", "", "Repository to upload issue attachments to. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	uploadCmd.Flags().Var(uploadOptions.IssueID, "issue", "Issue to upload attachments to")
 	uploadCmd.Flags().BoolVar(&uploadOptions.Progress, "progress", false, "Show progress")
 	_ = uploadCmd.MarkFlagRequired("issue")

--- a/cmd/issue/comment/create.go
+++ b/cmd/issue/comment/create.go
@@ -33,7 +33,7 @@ func init() {
 	Command.AddCommand(createCmd)
 
 	createOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
-	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create an issue comment into. Defaults to the current repository")
+	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create an issue comment into. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	createCmd.Flags().Var(createOptions.IssueID, "issue", "Issue to create comments to")
 	createCmd.Flags().StringVar(&createOptions.Comment, "comment", "", "Comment of the issue")
 	_ = createCmd.MarkFlagRequired("issue")

--- a/cmd/issue/comment/delete.go
+++ b/cmd/issue/comment/delete.go
@@ -30,7 +30,7 @@ func init() {
 	Command.AddCommand(deleteCmd)
 
 	deleteOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
-	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete an issue comment from. Defaults to the current repository")
+	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete an issue comment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	deleteCmd.Flags().Var(deleteOptions.IssueID, "issue", "Issue to delete comments from")
 	_ = deleteCmd.MarkFlagRequired("issue")
 	_ = deleteCmd.RegisterFlagCompletionFunc(deleteOptions.IssueID.CompletionFunc("issue"))

--- a/cmd/issue/comment/get.go
+++ b/cmd/issue/comment/get.go
@@ -31,7 +31,7 @@ func init() {
 
 	getOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get an issue comment from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get an issue comment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.IssueID, "issue", "Issue to get comments from")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.MarkFlagRequired("issue")

--- a/cmd/issue/comment/list.go
+++ b/cmd/issue/comment/list.go
@@ -34,7 +34,7 @@ func init() {
 	listOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list issue comments from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list issue comments from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.IssueID, "issue", "Issue to list comments from")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter comments")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")

--- a/cmd/issue/comment/update.go
+++ b/cmd/issue/comment/update.go
@@ -34,7 +34,7 @@ func init() {
 	Command.AddCommand(updateCmd)
 
 	updateOptions.IssueID = flags.NewEnumFlagWithFunc("", GetIssueIDs)
-	updateCmd.Flags().StringVar(&updateOptions.Repository, "repository", "", "Repository to update an issue into. Defaults to the current repository")
+	updateCmd.Flags().StringVar(&updateOptions.Repository, "repository", "", "Repository to update an issue into. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	updateCmd.Flags().Var(updateOptions.IssueID, "issue", "Issue to update comments to")
 	updateCmd.Flags().StringVar(&updateOptions.Comment, "comment", "", "Updated comment of the issue")
 	_ = updateCmd.MarkFlagRequired("issue")

--- a/cmd/issue/create.go
+++ b/cmd/issue/create.go
@@ -44,7 +44,7 @@ func init() {
 
 	createOptions.Kind = flags.NewEnumFlag("+bug", "enhancement", "proposal", "task")
 	createOptions.Priority = flags.NewEnumFlag("+major", "trivial", "minor", "major", "critical", "blocker")
-	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create an issue into. Defaults to the current repository")
+	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create an issue into. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	createCmd.Flags().StringVar(&createOptions.Title, "title", "", "Title of the issue")
 	createCmd.Flags().Var(createOptions.Kind, "kind", "Kind of the issue")
 	createCmd.Flags().Var(createOptions.Priority, "priority", "Priority of the issue")

--- a/cmd/issue/delete.go
+++ b/cmd/issue/delete.go
@@ -27,7 +27,7 @@ var deleteOptions struct {
 func init() {
 	Command.AddCommand(deleteCmd)
 
-	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete an issue from. Defaults to the current repository")
+	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete an issue from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func deleteValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/issue/get.go
+++ b/cmd/issue/get.go
@@ -30,7 +30,7 @@ func init() {
 	Command.AddCommand(getCmd)
 
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get an issue from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get an issue from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().BoolVar(&getOptions.Changes, "changes", false, "Display changes")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.RegisterFlagCompletionFunc(getOptions.Columns.CompletionFunc("columns"))

--- a/cmd/issue/list.go
+++ b/cmd/issue/list.go
@@ -34,7 +34,7 @@ func init() {
 	listOptions.States = flags.NewEnumSliceFlagWithAllAllowed("closed", "duplicate", "invalid", "on hold", "+new", "+open", "resolved", "submitted", "wontfix")
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list issues from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list issues from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.States, "state", "State of the issues to list. Can be repeated. One of: all, closed, duplicate, invalid, on hold, new, open, resolved, submitted, wontfix. Default: open, new")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter issues")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")

--- a/cmd/issue/unvote.go
+++ b/cmd/issue/unvote.go
@@ -25,7 +25,7 @@ var unvoteOptions struct {
 func init() {
 	Command.AddCommand(unvoteCmd)
 
-	unvoteCmd.Flags().StringVar(&unvoteOptions.Repository, "repository", "", "Repository to unvote an issue from. Defaults to the current repository")
+	unvoteCmd.Flags().StringVar(&unvoteOptions.Repository, "repository", "", "Repository to unvote an issue from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func unvoteValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/issue/unwatch.go
+++ b/cmd/issue/unwatch.go
@@ -25,7 +25,7 @@ var unwatchOptions struct {
 func init() {
 	Command.AddCommand(unwatchCmd)
 
-	unwatchCmd.Flags().StringVar(&unwatchOptions.Repository, "repository", "", "Repository to unwatch an issue from. Defaults to the current repository")
+	unwatchCmd.Flags().StringVar(&unwatchOptions.Repository, "repository", "", "Repository to unwatch an issue from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func unwatchValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/issue/update.go
+++ b/cmd/issue/update.go
@@ -47,7 +47,7 @@ func init() {
 
 	updateOptions.Kind = flags.NewEnumFlag("bug", "enhancement", "proposal", "task")
 	updateOptions.Priority = flags.NewEnumFlag("major", "trivial", "minor", "major", "critical", "blocker")
-	updateCmd.Flags().StringVar(&updateOptions.Repository, "repository", "", "Repository to update an issue from. Defaults to the current repository")
+	updateCmd.Flags().StringVar(&updateOptions.Repository, "repository", "", "Repository to update an issue from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	updateCmd.Flags().StringVar(&updateOptions.Title, "title", "", "Title of the issue")
 	updateCmd.Flags().Var(updateOptions.Kind, "kind", "Kind of the issue")
 	updateCmd.Flags().Var(updateOptions.Priority, "priority", "Priority of the issue")

--- a/cmd/issue/vote.go
+++ b/cmd/issue/vote.go
@@ -25,7 +25,7 @@ var voteOptions struct {
 func init() {
 	Command.AddCommand(voteCmd)
 
-	voteCmd.Flags().StringVar(&voteOptions.Repository, "repository", "", "Repository to vote an issue from. Defaults to the current repository")
+	voteCmd.Flags().StringVar(&voteOptions.Repository, "repository", "", "Repository to vote an issue from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func voteValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/issue/watch.go
+++ b/cmd/issue/watch.go
@@ -26,7 +26,7 @@ var watchOptions struct {
 func init() {
 	Command.AddCommand(watchCmd)
 
-	watchCmd.Flags().StringVar(&watchOptions.Repository, "repository", "", "Repository to watch an issue from. Defaults to the current repository")
+	watchCmd.Flags().StringVar(&watchOptions.Repository, "repository", "", "Repository to watch an issue from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	watchCmd.Flags().BoolVar(&watchOptions.Check, "check", false, "Check if the issue is watched")
 }
 

--- a/cmd/pipeline/get.go
+++ b/cmd/pipeline/get.go
@@ -30,7 +30,7 @@ func init() {
 	Command.AddCommand(getCmd)
 
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.RegisterFlagCompletionFunc(getOptions.Columns.CompletionFunc("columns"))
 }

--- a/cmd/pipeline/list.go
+++ b/cmd/pipeline/list.go
@@ -34,7 +34,7 @@ func init() {
 
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pipelines from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pipelines from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter pipelines")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")
 	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by (applies a local sort on fetched results; server-side sort is always by creation date descending)")

--- a/cmd/pipeline/step/cases.go
+++ b/cmd/pipeline/step/cases.go
@@ -32,7 +32,7 @@ func init() {
 	Command.AddCommand(casesCmd)
 
 	casesOptions.PipelineID = flags.NewEnumFlagWithFunc("", plcommon.GetPipelineIDs)
-	casesCmd.Flags().StringVar(&casesOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository")
+	casesCmd.Flags().StringVar(&casesOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	casesCmd.Flags().Var(casesOptions.PipelineID, "pipeline", "Pipeline to list steps from")
 	_ = casesCmd.MarkFlagRequired("pipeline")
 	_ = casesCmd.RegisterFlagCompletionFunc(casesOptions.PipelineID.CompletionFunc("pipeline"))

--- a/cmd/pipeline/step/get.go
+++ b/cmd/pipeline/step/get.go
@@ -34,7 +34,7 @@ func init() {
 
 	getOptions.PipelineID = flags.NewEnumFlagWithFunc("", plcommon.GetPipelineIDs)
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.PipelineID, "pipeline", "Pipeline to list steps from")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	getCmd.Flags().BoolVar(&getOptions.ShowLogsCommand, "show-logs-command", false, "Show the command to get the logs for this step")

--- a/cmd/pipeline/step/list.go
+++ b/cmd/pipeline/step/list.go
@@ -36,7 +36,7 @@ func init() {
 	listOptions.PipelineID = flags.NewEnumFlagWithFunc("", plcommon.GetPipelineIDs)
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pipeline steps from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pipeline steps from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.PipelineID, "pipeline", "Pipeline to list steps from")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")
 	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by")

--- a/cmd/pipeline/step/logs.go
+++ b/cmd/pipeline/step/logs.go
@@ -32,7 +32,7 @@ func init() {
 	Command.AddCommand(logCmd)
 
 	logOptions.PipelineID = flags.NewEnumFlagWithFunc("", plcommon.GetPipelineIDs)
-	logCmd.Flags().StringVar(&logOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository")
+	logCmd.Flags().StringVar(&logOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	logCmd.Flags().Var(logOptions.PipelineID, "pipeline", "Pipeline to list steps from")
 	_ = logCmd.MarkFlagRequired("pipeline")
 	_ = logCmd.RegisterFlagCompletionFunc(logOptions.PipelineID.CompletionFunc("pipeline"))

--- a/cmd/pipeline/step/report.go
+++ b/cmd/pipeline/step/report.go
@@ -32,7 +32,7 @@ func init() {
 	Command.AddCommand(reportCmd)
 
 	reportOptions.PipelineID = flags.NewEnumFlagWithFunc("", plcommon.GetPipelineIDs)
-	reportCmd.Flags().StringVar(&reportOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository")
+	reportCmd.Flags().StringVar(&reportOptions.Repository, "repository", "", "Repository to get pipeline from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	reportCmd.Flags().Var(reportOptions.PipelineID, "pipeline", "Pipeline to list steps from")
 	_ = reportCmd.MarkFlagRequired("pipeline")
 	_ = reportCmd.RegisterFlagCompletionFunc(reportOptions.PipelineID.CompletionFunc("pipeline"))

--- a/cmd/pipeline/stop.go
+++ b/cmd/pipeline/stop.go
@@ -25,7 +25,7 @@ var stopOptions struct {
 func init() {
 	Command.AddCommand(stopCmd)
 
-	stopCmd.Flags().StringVar(&stopOptions.Repository, "repository", "", "Repository to stop pipeline in. Defaults to the current repository")
+	stopCmd.Flags().StringVar(&stopOptions.Repository, "repository", "", "Repository to stop pipeline in. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func stopProcess(cmd *cobra.Command, args []string) (err error) {

--- a/cmd/pipeline/trigger.go
+++ b/cmd/pipeline/trigger.go
@@ -43,7 +43,7 @@ func init() {
 	triggerOptions.Branch = flags.NewEnumFlagWithFunc("", branch.GetBranchNames)
 	triggerOptions.Commit = flags.NewEnumFlagWithFunc("", commit.GetCommitHashes)
 	triggerOptions.Tag = flags.NewEnumFlagWithFunc("", tag.GetTagNames)
-	triggerCmd.Flags().StringVar(&triggerOptions.Repository, "repository", "", "Repository to trigger pipeline in. Defaults to the current repository")
+	triggerCmd.Flags().StringVar(&triggerOptions.Repository, "repository", "", "Repository to trigger pipeline in. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	triggerCmd.Flags().Var(triggerOptions.Branch, "branch", "Branch to run the pipeline on")
 	triggerCmd.Flags().Var(triggerOptions.Tag, "tag", "Tag to run the pipeline on")
 	triggerCmd.Flags().Var(triggerOptions.Commit, "commit", "Specific commit hash to run the pipeline on")

--- a/cmd/profile/profile_client.go
+++ b/cmd/profile/profile_client.go
@@ -482,9 +482,21 @@ func (profile Profile) getRepositoryFullname(context context.Context, cmd *cobra
 		log.Debugf("No repository name given, trying to get it from the current git repository")
 		remote, err := remote.GetFromGitConfig(context, "origin")
 		if err != nil {
-			return "", errors.Join(errors.NotFound.With("current repository"), err)
+			return "", errors.Join(
+				errors.New("Use --repository <workspace>/<repository> or <repository> with a default workspace in your profile"),
+				errors.NotFound.With("current", "repository"),
+				err,
+			)
 		}
 		fullName = remote.RepositoryName()
+	} else if !strings.Contains(fullName, "/") && len(profile.DefaultWorkspace) > 0 {
+		log.Debugf("Repository name %q has no workspace prefix, prepending default workspace %q", fullName, profile.DefaultWorkspace)
+		fullName = profile.DefaultWorkspace + "/" + fullName
+	} else if !strings.Contains(fullName, "/") {
+		return "", errors.Join(
+			errors.New("Expected <workspace>/<repository> or a default workspace must be defined in your profile"),
+			errors.ArgumentInvalid.With("repository", fullName),
+		)
 	}
 	return fullName, nil
 }

--- a/cmd/pullrequest/activity/list.go
+++ b/cmd/pullrequest/activity/list.go
@@ -36,7 +36,7 @@ func init() {
 	listOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pullrequest activities from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pullrequest activities from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.PullRequestID, "pullrequest", "pullrequest to list activities from")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter activities")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")

--- a/cmd/pullrequest/approve.go
+++ b/cmd/pullrequest/approve.go
@@ -27,7 +27,7 @@ var approveOptions struct {
 func init() {
 	Command.AddCommand(approveCmd)
 
-	approveCmd.Flags().StringVar(&approveOptions.Repository, "repository", "", "Repository to approve pullrequest from. Defaults to the current repository")
+	approveCmd.Flags().StringVar(&approveOptions.Repository, "repository", "", "Repository to approve pullrequest from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func approveValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/pullrequest/comment/create.go
+++ b/cmd/pullrequest/comment/create.go
@@ -49,7 +49,7 @@ func init() {
 	Command.AddCommand(createCmd)
 
 	createOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
-	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create a pullrequest comment into. Defaults to the current repository")
+	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create a pullrequest comment into. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	createCmd.Flags().Var(createOptions.PullRequestID, "pullrequest", "Pullrequest to create comments to")
 	createCmd.Flags().StringVar(&createOptions.Comment, "comment", "", "Comment of the pullrequest")
 	createCmd.Flags().StringVar(&createOptions.File, "file", "", "File to comment on")

--- a/cmd/pullrequest/comment/delete.go
+++ b/cmd/pullrequest/comment/delete.go
@@ -31,7 +31,7 @@ func init() {
 	Command.AddCommand(deleteCmd)
 
 	deleteOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
-	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete a pullrequest comment from. Defaults to the current repository")
+	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete a pullrequest comment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	deleteCmd.Flags().Var(deleteOptions.PullRequestID, "pullrequest", "Pullrequest to delete comments from")
 	_ = deleteCmd.MarkFlagRequired("pullrequest")
 	_ = deleteCmd.RegisterFlagCompletionFunc(deleteOptions.PullRequestID.CompletionFunc("pullrequest"))

--- a/cmd/pullrequest/comment/get.go
+++ b/cmd/pullrequest/comment/get.go
@@ -32,7 +32,7 @@ func init() {
 
 	getOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a pullrequest comment from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a pullrequest comment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.PullRequestID, "pullrequest", "Pullrequest to get comments from")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.MarkFlagRequired("pullrequest")

--- a/cmd/pullrequest/comment/list.go
+++ b/cmd/pullrequest/comment/list.go
@@ -36,7 +36,7 @@ func init() {
 	listOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pullrequest comments from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pullrequest comments from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.PullRequestID, "pullrequest", "pullrequest to list comments from")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter comments")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")

--- a/cmd/pullrequest/comment/reopen.go
+++ b/cmd/pullrequest/comment/reopen.go
@@ -30,7 +30,7 @@ func init() {
 	Command.AddCommand(reopenCmd)
 
 	reopenOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
-	reopenCmd.Flags().StringVar(&reopenOptions.Repository, "repository", "", "Repository to reopen a pullrequest comment from. Defaults to the current repository")
+	reopenCmd.Flags().StringVar(&reopenOptions.Repository, "repository", "", "Repository to reopen a pullrequest comment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	reopenCmd.Flags().Var(reopenOptions.PullRequestID, "pullrequest", "Pullrequest to reopen comments from")
 	_ = reopenCmd.MarkFlagRequired("pullrequest")
 	_ = reopenCmd.RegisterFlagCompletionFunc(reopenOptions.PullRequestID.CompletionFunc("pullrequest"))

--- a/cmd/pullrequest/comment/resolve.go
+++ b/cmd/pullrequest/comment/resolve.go
@@ -30,7 +30,7 @@ func init() {
 	Command.AddCommand(resolveCmd)
 
 	resolveOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
-	resolveCmd.Flags().StringVar(&resolveOptions.Repository, "repository", "", "Repository to resolve a pullrequest comment from. Defaults to the current repository")
+	resolveCmd.Flags().StringVar(&resolveOptions.Repository, "repository", "", "Repository to resolve a pullrequest comment from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	resolveCmd.Flags().Var(resolveOptions.PullRequestID, "pullrequest", "Pullrequest to resolve comments from")
 	_ = resolveCmd.MarkFlagRequired("pullrequest")
 	_ = resolveCmd.RegisterFlagCompletionFunc(resolveOptions.PullRequestID.CompletionFunc("pullrequest"))

--- a/cmd/pullrequest/comment/update.go
+++ b/cmd/pullrequest/comment/update.go
@@ -44,7 +44,7 @@ func init() {
 	Command.AddCommand(updateCmd)
 
 	updateOptions.PullRequestID = flags.NewEnumFlagWithFunc("", prcommon.GetPullRequestIDs)
-	updateCmd.Flags().StringVar(&updateOptions.Repository, "repository", "", "Repository to update a pullrequest comment into. Defaults to the current repository")
+	updateCmd.Flags().StringVar(&updateOptions.Repository, "repository", "", "Repository to update a pullrequest comment into. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	updateCmd.Flags().Var(updateOptions.PullRequestID, "pullrequest", "Pullrequest to update comments to")
 	updateCmd.Flags().StringVar(&updateOptions.Comment, "comment", "", "Updated comment of the pullrequest")
 	updateCmd.Flags().StringVar(&updateOptions.File, "file", "", "File to comment on")

--- a/cmd/pullrequest/create.go
+++ b/cmd/pullrequest/create.go
@@ -55,7 +55,7 @@ func init() {
 	createOptions.Destination = flags.NewEnumFlagWithFunc("", branch.GetBranchNames)
 	createOptions.Reviewers = flags.NewEnumSliceFlagWithAllAllowedAndFunc(GetReviewerNicknames)
 
-	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create pullrequest in. Defaults to the current repository")
+	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create pullrequest in. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	createCmd.Flags().StringVar(&createOptions.Title, "title", "", "Title of the pullrequest")
 	createCmd.Flags().StringVar(&createOptions.Description, "description", "", "Description of the pullrequest")
 	createCmd.Flags().Var(createOptions.Source, "source", "Source branch of the pullrequest")

--- a/cmd/pullrequest/decline.go
+++ b/cmd/pullrequest/decline.go
@@ -27,7 +27,7 @@ var declineOptions struct {
 func init() {
 	Command.AddCommand(declineCmd)
 
-	declineCmd.Flags().StringVar(&declineOptions.Repository, "repository", "", "Repository to decline pullrequest from. Defaults to the current repository")
+	declineCmd.Flags().StringVar(&declineOptions.Repository, "repository", "", "Repository to decline pullrequest from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func declineValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/pullrequest/get.go
+++ b/cmd/pullrequest/get.go
@@ -30,7 +30,7 @@ func init() {
 	Command.AddCommand(getCmd)
 
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get pullrequest from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get pullrequest from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.RegisterFlagCompletionFunc(getOptions.Columns.CompletionFunc("columns"))
 }

--- a/cmd/pullrequest/list.go
+++ b/cmd/pullrequest/list.go
@@ -35,7 +35,7 @@ func init() {
 	listOptions.State = flags.NewEnumFlag("all", "declined", "merged", "+open", "superseded")
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pullrequests from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list pullrequests from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.State, "state", "Pull request state to fetch. Defaults to \"open\"")
 	listCmd.Flags().StringVar(&listOptions.Query, "query", "", "Query string to filter pull requests")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")

--- a/cmd/pullrequest/merge.go
+++ b/cmd/pullrequest/merge.go
@@ -34,7 +34,7 @@ func init() {
 	Command.AddCommand(mergeCmd)
 
 	mergeOptions.MergeStrategy = flags.NewEnumFlag("+merge_commit", "squash", "fast_forward")
-	mergeCmd.Flags().StringVar(&mergeOptions.Repository, "repository", "", "Repository to merge pullrequest from. Defaults to the current repository")
+	mergeCmd.Flags().StringVar(&mergeOptions.Repository, "repository", "", "Repository to merge pullrequest from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	mergeCmd.Flags().StringVar(&mergeOptions.Message, "message", "", "Message of the merge")
 	mergeCmd.Flags().BoolVar(&mergeOptions.CloseSourceBranch, "close-source-branch", false, "Close the source branch of the pullrequest")
 	mergeCmd.Flags().Var(mergeOptions.MergeStrategy, "merge-strategy", "Merge strategy to use. Possible values are \"merge_commit\", \"squash\" or \"fast_forward\"")

--- a/cmd/pullrequest/unapprove.go
+++ b/cmd/pullrequest/unapprove.go
@@ -26,7 +26,7 @@ var unapproveOptions struct {
 func init() {
 	Command.AddCommand(unapproveCmd)
 
-	unapproveCmd.Flags().StringVar(&unapproveOptions.Repository, "repository", "", "Repository to unapprove pullrequest from. Defaults to the current repository")
+	unapproveCmd.Flags().StringVar(&unapproveOptions.Repository, "repository", "", "Repository to unapprove pullrequest from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func unapproveValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/tag/create.go
+++ b/cmd/tag/create.go
@@ -31,7 +31,7 @@ func init() {
 	Command.AddCommand(createCmd)
 
 	createOptions.Commit = flags.NewEnumFlagWithFunc("latest", commit.GetCommitHashes)
-	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create a tag into. Defaults to the current repository")
+	createCmd.Flags().StringVar(&createOptions.Repository, "repository", "", "Repository to create a tag into. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	createCmd.Flags().StringVar(&createOptions.Name, "name", "", "Name of the tag")
 	createCmd.Flags().StringVar(&createOptions.Message, "message", "", "Message of the tag")
 	createCmd.Flags().Var(createOptions.Commit, "commit", "Target commit hash for the tag. Defaults to the latest commit")

--- a/cmd/tag/delete.go
+++ b/cmd/tag/delete.go
@@ -27,7 +27,7 @@ var deleteOptions struct {
 func init() {
 	Command.AddCommand(deleteCmd)
 
-	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete a tag from. Defaults to the current repository")
+	deleteCmd.Flags().StringVar(&deleteOptions.Repository, "repository", "", "Repository to delete a tag from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 }
 
 func deleteValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/tag/get.go
+++ b/cmd/tag/get.go
@@ -28,7 +28,7 @@ func init() {
 	Command.AddCommand(getCmd)
 
 	getOptions.Columns = flags.NewEnumSliceFlag(columns.Columns()...)
-	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a tag from. Defaults to the current repository")
+	getCmd.Flags().StringVar(&getOptions.Repository, "repository", "", "Repository to get a tag from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	getCmd.Flags().Var(getOptions.Columns, "columns", "Comma-separated list of columns to display")
 	_ = getCmd.RegisterFlagCompletionFunc(getOptions.Columns.CompletionFunc("columns"))
 }

--- a/cmd/tag/list.go
+++ b/cmd/tag/list.go
@@ -30,7 +30,7 @@ func init() {
 
 	listOptions.Columns = flags.NewEnumSliceFlagWithAllAllowed(columns.Columns()...)
 	listOptions.SortBy = flags.NewEnumFlag(columns.Sorters()...)
-	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list tags from. Defaults to the current repository")
+	listCmd.Flags().StringVar(&listOptions.Repository, "repository", "", "Repository to list tags from. Defaults to the current repository.\nExpected format: <workspace>/<repository> or <repository>.\nIf only <repository> is given, the profile's default workspace is used.")
 	listCmd.Flags().Var(listOptions.Columns, "columns", "Comma-separated list of columns to display")
 	listCmd.Flags().Var(listOptions.SortBy, "sort", "Column to sort by")
 	listCmd.Flags().IntVar(&listOptions.PageLength, "page-length", 0, "Number of items per page to retrieve from Bitbucket. Default is the profile's default page length")


### PR DESCRIPTION
This change improves repository name resolution for repo-scoped commands and updates CLI help text to reduce ambiguity.

**What changed**
1. getRepositoryFullname() now prepends profile.DefaultWorkspace when --repository is a bare slug.
2. Added explicit validation error when --repository is a bare slug and no default-workspace is configured.
3. Added clearer error when no repository can be resolved from flags or git origin.
4. Updated --repository help text across repo-scoped commands:
    - keeps “Defaults to the current repository”
    - adds expected format <workspace>/<repository>
    - documents bare-slug fallback via default-workspace

**Why**
Previously, bare slugs could produce malformed repository API paths and cryptic API errors.
Now behavior is explicit and failure modes are actionable.