### PR TITLE
Add AUR (Arch Linux User Repository) packaging and auto-publish workflow

### DIFF
--- a/.github/workflows/publish-aur.yml
+++ b/.github/workflows/publish-aur.yml
@@ -1,0 +1,65 @@
+name: Publish to AUR
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  aur-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          # Strip leading 'v' from tag (e.g. v0.18.0 -> 0.18.0)
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install archlinux packaging tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y pacman-package-manager 2>/dev/null || true
+
+      - name: Generate PKGBUILD
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -eo pipefail
+
+          # Copy template and pin version
+          cp packaging/aur/PKGBUILD PKGBUILD
+          sed -i "s/^pkgver=.*/pkgver=$VERSION/" PKGBUILD
+          sed -i "s/^pkgrel=.*/pkgrel=1/" PKGBUILD
+
+          # Download sources and compute checksums.
+          # PKGBUILD variables ($url, $pkgver) resolve naturally here.
+          if command -v updpkgsums &>/dev/null; then
+            updpkgsums
+          else
+            # Manual fallback: compute checksums directly
+            AMD64_SHA=$(curl -sL --fail \
+              "https://github.com/gildas/bitbucket-cli/releases/download/v$VERSION/bitbucket-cli_${VERSION}_linux_amd64.tar.gz" \
+              | sha256sum | cut -d' ' -f1)
+            ARM64_SHA=$(curl -sL --fail \
+              "https://github.com/gildas/bitbucket-cli/releases/download/v$VERSION/bitbucket-cli_${VERSION}_linux_arm64.tar.gz" \
+              | sha256sum | cut -d' ' -f1)
+            LICENSE_SHA=$(curl -sL --fail \
+              "https://github.com/gildas/bitbucket-cli/raw/v$VERSION/LICENSE" \
+              | sha256sum | cut -d' ' -f1)
+
+            sed -i "/^sha256sums_x86_64=(/,/)/c\sha256sums_x86_64=(\"$AMD64_SHA\" \"$LICENSE_SHA\")" PKGBUILD
+            sed -i "/^sha256sums_aarch64=(/,/)/c\sha256sums_aarch64=(\"$ARM64_SHA\" \"$LICENSE_SHA\")" PKGBUILD
+          fi
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@da03e160361ce01bf087e790b6ffd196d7dccff7 # v4.1.3
+        with:
+          pkgname: bitbucket-cli-bin
+          pkgbuild: ./PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          ssh_keyscan_types: rsa,ecdsa,ed25519

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ sudo snap alias bitbucket-cli bb
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/bitbucket-cli)
 
+You can also install `bb` on Arch Linux from the [AUR](https://aur.archlinux.org/packages/bitbucket-cli-bin):
+
+```bash
+paru -S bitbucket-cli-bin
+# or
+yay -S bitbucket-cli-bin
+```
+
 ### macOS
 
 You can get `bb` from [Homebrew](https://brew.sh) with:

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,0 +1,25 @@
+pkgbase = bitbucket-cli-bin
+	pkgdesc = The missing command line interface for Bitbucket
+	pkgver = 0.18.0
+	pkgrel = 1
+	url = https://github.com/gildas/bitbucket-cli
+	arch = x86_64
+	arch = aarch64
+	license = MIT
+	optdepends = gnome-keyring: Secret Service backend for credential storage
+	provides = bitbucket-cli=0.18.0
+	provides = bb=0.18.0
+	conflicts = bitbucket-cli
+	conflicts = bitbucket-cli-git
+	options = !strip
+	options = !debug
+	source_x86_64 = https://github.com/gildas/bitbucket-cli/releases/download/v0.18.0/bitbucket-cli_0.18.0_linux_amd64.tar.gz
+	source_x86_64 = LICENSE::https://github.com/gildas/bitbucket-cli/raw/v0.18.0/LICENSE
+	sha256sums_x86_64 = b2f8759dde04ed1555d21c183d98f43dc0c500550f1878ab023e9e6ab5d5beeb
+	sha256sums_x86_64 = 476c049bd9aac064131760d13a1dfdebcb20d0e00d3536df08f3c2672755d5eb
+	source_aarch64 = https://github.com/gildas/bitbucket-cli/releases/download/v0.18.0/bitbucket-cli_0.18.0_linux_arm64.tar.gz
+	source_aarch64 = LICENSE::https://github.com/gildas/bitbucket-cli/raw/v0.18.0/LICENSE
+	sha256sums_aarch64 = 467ed7ece88210e22f699811522c0d6b30e89a5c578c51a73add291862ddf2c8
+	sha256sums_aarch64 = 476c049bd9aac064131760d13a1dfdebcb20d0e00d3536df08f3c2672755d5eb
+
+pkgname = bitbucket-cli-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,36 @@
+# Maintainer: Gildas Cherruel <gildas@breizh.org>
+pkgname=bitbucket-cli-bin
+pkgver=0.18.0
+pkgrel=1
+pkgdesc="The missing command line interface for Bitbucket"
+url="https://github.com/gildas/bitbucket-cli"
+license=("MIT")
+arch=("x86_64" "aarch64")
+provides=("bitbucket-cli=$pkgver" "bb=$pkgver")
+conflicts=("bitbucket-cli" "bitbucket-cli-git")
+options=("!strip" "!debug")
+optdepends=("gnome-keyring: Secret Service backend for credential storage")
+source_x86_64=("$url/releases/download/v$pkgver/bitbucket-cli_${pkgver}_linux_amd64.tar.gz"
+               "LICENSE::$url/raw/v$pkgver/LICENSE")
+source_aarch64=("$url/releases/download/v$pkgver/bitbucket-cli_${pkgver}_linux_arm64.tar.gz"
+                "LICENSE::$url/raw/v$pkgver/LICENSE")
+sha256sums_x86_64=("b2f8759dde04ed1555d21c183d98f43dc0c500550f1878ab023e9e6ab5d5beeb"
+                   "476c049bd9aac064131760d13a1dfdebcb20d0e00d3536df08f3c2672755d5eb")
+sha256sums_aarch64=("467ed7ece88210e22f699811522c0d6b30e89a5c578c51a73add291862ddf2c8"
+                    "476c049bd9aac064131760d13a1dfdebcb20d0e00d3536df08f3c2672755d5eb")
+
+package() {
+  install -Dm755 bb "$pkgdir/usr/bin/bb"
+
+  # License
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+
+  # Shell completions
+  "$pkgdir/usr/bin/bb" completion bash > bb-completion.bash
+  "$pkgdir/usr/bin/bb" completion zsh > _bb
+  "$pkgdir/usr/bin/bb" completion fish > bb.fish
+
+  install -Dm644 bb-completion.bash "$pkgdir/usr/share/bash-completion/completions/bb"
+  install -Dm644 _bb "$pkgdir/usr/share/zsh/site-functions/_bb"
+  install -Dm644 bb.fish "$pkgdir/usr/share/fish/vendor_completions.d/bb.fish"
+}


### PR DESCRIPTION
## Summary

Adds packaging support for the Arch Linux User Repository (AUR), alongside the existing deb/rpm/snap/chocolatey/homebrew packaging.

The package is published as `bitbucket-cli-bin` — a `-bin` variant that ships pre-built binaries from GitHub releases.

## What's included

| File | Purpose |
|------|---------|
| `packaging/aur/PKGBUILD` | Package definition with real SHA256 checksums, LICENSE installation, optdepends for Secret Service backend, and shell completions (bash, zsh, fish) |
| `packaging/aur/.SRCINFO` | Machine-readable package metadata |
| `.github/workflows/publish-aur.yml` | GitHub Action — auto-publishes to AUR on release. Uses `updpkgsums` with manual fallback, pinned action commit SHA for supply chain security |
| `README.md` | Added Arch Linux installation section |

## Setup instructions (one-time, for the maintainer)

The GitHub Action can only update an existing AUR package. The initial submission must be done manually.

### 1. Create an AUR account
Register at https://aur.archlinux.org/register

### 2. Generate an SSH key for CI
```
ssh-keygen -t ed25519 -C "github-actions@bitbucket-cli"
```

### 3. Add the public key to your AUR account
Go to https://aur.archlinux.org → Account → SSH Keys → paste the public key

### 4. Add GitHub repository secrets
In this repo's Settings → Secrets and variables → Actions, add:

| Secret | Value |
|--------|-------|
| `AUR_SSH_PRIVATE_KEY` | The ed25519 private key (full contents) |
| `AUR_USERNAME` | Your AUR username |
| `AUR_EMAIL` | Your AUR email |

### 5. Create the initial AUR package (one-time, manual)
```
git clone ssh://aur@aur.archlinux.org/bitbucket-cli-bin.git
cd bitbucket-cli-bin
cp /path/to/bitbucket-cli/packaging/aur/PKGBUILD .
cp /path/to/bitbucket-cli/packaging/aur/.SRCINFO .
sed -i "s/^pkgver=.*/pkgver=0.18.0/" PKGBUILD
updpkgsums
makepkg --printsrcinfo > .SRCINFO
git add PKGBUILD .SRCINFO
git commit -m "Initial upload: bitbucket-cli-bin 0.18.0"
git push
```

After this, every new GitHub release will automatically update the AUR package via the workflow.

## Notes
- **Runtime dependency:** `gnome-keyring` (optdepends) — provides the Secret Service daemon needed by go-keyring for credential storage. libsecret alone is a client library without a running daemon.
- **License:** MIT — automatically installed to /usr/share/licenses/bitbucket-cli-bin/LICENSE
- **Dual architecture:** x86_64 and aarch64
- **Shell completions:** bash, zsh, fish
- **Supply chain security:** The AUR publish action is pinned to commit da03e160 (v4.1.3) rather than a mutable tag